### PR TITLE
HG-51: fix events ordering in test storage backend

### DIFF
--- a/apps/mg/src/mg_storage_test.erl
+++ b/apps/mg/src/mg_storage_test.erl
@@ -231,12 +231,8 @@ do_add_events(ID, NewMachineEvents, State) ->
     mg:history().
 do_get_history(ID, Machine, RequestedRange, State=#{events:=Events}) ->
     ok = check_machine_version(ID, Machine, State),
-    maps:values(
-        maps:with(
-            mg_storage_utils:get_machine_events_ids(ID, Machine, RequestedRange),
-            Events
-        )
-    ).
+    EventsIDs = mg_storage_utils:get_machine_events_ids(ID, Machine, RequestedRange),
+    [maps:get(EventID, Events) || EventID <- EventsIDs].
 
 -spec do_store_machine(mg:id(), mg_storage:machine(), state()) ->
     state().


### PR DESCRIPTION
Когда было больше 32х эвентов они начинали путаться.
