### PR TITLE
move logic errors to info log level

### DIFF
--- a/apps/mg/src/mg_events_machine.erl
+++ b/apps/mg/src/mg_events_machine.erl
@@ -199,7 +199,7 @@ ref2id(_, {id, ID}) ->
     ID;
 ref2id(Options, {tag, Tag}) ->
     case mg_machine_tags:resolve(tags_machine_options(Options), Tag) of
-        undefined -> throw(machine_not_found);
+        undefined -> throw({logic, machine_not_found});
         ID        -> ID
     end.
 

--- a/apps/mg/src/mg_events_sink.erl
+++ b/apps/mg/src/mg_events_sink.erl
@@ -247,7 +247,7 @@ make_ext_id(EventSinkID, SourceNS, SourceMachineID, EventID) ->
 get_state(Options, EventSinkID) ->
     try
         opaque_to_state(mg_machine:get(machine_options(Options), EventSinkID))
-    catch throw:machine_not_found ->
+    catch throw:{logic, machine_not_found} ->
         new_state()
     end.
 

--- a/apps/mg/src/mg_machine_tags.erl
+++ b/apps/mg/src/mg_machine_tags.erl
@@ -56,7 +56,7 @@ replace(Options, Tag, ID, ReqCtx, Deadline) ->
 resolve(Options, Tag) ->
     try
         opaque_to_state(mg_machine:get(machine_options(Options), Tag))
-    catch throw:machine_not_found ->
+    catch throw:{logic, machine_not_found} ->
         undefined
     end.
 

--- a/apps/mg/test/mg_machine_SUITE.erl
+++ b/apps/mg/test/mg_machine_SUITE.erl
@@ -76,10 +76,12 @@ simple_test(_) ->
     ID = <<"42">>,
     _  = start_automaton(Options),
 
-    machine_not_found = (catch mg_machine:call(Options, ID, get, ?req_ctx, mg_utils:default_deadline())),
+    {logic, machine_not_found} =
+        (catch mg_machine:call(Options, ID, get, ?req_ctx, mg_utils:default_deadline())),
 
     ok = mg_machine:start(Options, ID, {TestKey, 0}, ?req_ctx, mg_utils:default_deadline()),
-    machine_already_exist = (catch mg_machine:start(Options, ID, {TestKey, 0}, ?req_ctx, mg_utils:default_deadline())),
+    {logic, machine_already_exist} =
+        (catch mg_machine:start(Options, ID, {TestKey, 0}, ?req_ctx, mg_utils:default_deadline())),
 
     0  = mg_machine:call (Options, ID, get              , ?req_ctx, mg_utils:default_deadline()),
     ok = mg_machine:call (Options, ID, increment        , ?req_ctx, mg_utils:default_deadline()),
@@ -89,25 +91,28 @@ simple_test(_) ->
     2  = mg_machine:call (Options, ID, get              , ?req_ctx, mg_utils:default_deadline()),
 
     % call fail/simple_repair
-    machine_failed = (catch mg_machine:call         (Options, ID, fail, ?req_ctx, mg_utils:default_deadline())),
+    {logic, machine_failed} =
+        (catch mg_machine:call         (Options, ID, fail, ?req_ctx, mg_utils:default_deadline())),
     ok             =        mg_machine:simple_repair(Options, ID,       ?req_ctx, mg_utils:default_deadline()),
     2              =        mg_machine:call         (Options, ID, get , ?req_ctx, mg_utils:default_deadline()),
 
     % call fail/repair
-    machine_failed = (catch mg_machine:call  (Options, ID, fail      , ?req_ctx, mg_utils:default_deadline())),
-    repaired       =        mg_machine:repair(Options, ID, repair_arg, ?req_ctx, mg_utils:default_deadline()),
-    2              =        mg_machine:call  (Options, ID, get       , ?req_ctx, mg_utils:default_deadline()),
+    {logic, machine_failed} = (catch mg_machine:call  (Options, ID, fail      , ?req_ctx, mg_utils:default_deadline())),
+    repaired                =        mg_machine:repair(Options, ID, repair_arg, ?req_ctx, mg_utils:default_deadline()),
+    2                       =        mg_machine:call  (Options, ID, get       , ?req_ctx, mg_utils:default_deadline()),
 
     % call fail/repair fail/repair
-    machine_failed = (catch mg_machine:call(Options, ID, fail, ?req_ctx, mg_utils:default_deadline())),
-    machine_failed = (catch mg_machine:repair(Options, ID, fail, ?req_ctx, mg_utils:default_deadline())),
+    {logic, machine_failed} = (catch mg_machine:call(Options, ID, fail, ?req_ctx, mg_utils:default_deadline())),
+    {logic, machine_failed} = (catch mg_machine:repair(Options, ID, fail, ?req_ctx, mg_utils:default_deadline())),
     repaired = mg_machine:repair(Options, ID, repair_arg, ?req_ctx, mg_utils:default_deadline()),
-    machine_already_working = (catch mg_machine:repair(Options, ID, repair_arg, ?req_ctx, mg_utils:default_deadline())),
+    {logic, machine_already_working} =
+        (catch mg_machine:repair(Options, ID, repair_arg, ?req_ctx, mg_utils:default_deadline())),
     2  = mg_machine:call(Options, ID, get, ?req_ctx, mg_utils:default_deadline()),
 
     ok  = mg_machine:call(Options, ID, remove, ?req_ctx, mg_utils:default_deadline()),
 
-    machine_not_found = (catch mg_machine:call(Options, ID, get, ?req_ctx, mg_utils:default_deadline())),
+    {logic, machine_not_found} =
+        (catch mg_machine:call(Options, ID, get, ?req_ctx, mg_utils:default_deadline())),
 
     ok.
 

--- a/apps/mg/test/mg_machine_full_test_SUITE.erl
+++ b/apps/mg/test/mg_machine_full_test_SUITE.erl
@@ -140,10 +140,10 @@ do_action(Options, ID, Seq, Action) ->
                 mg_machine:call(Options, id(ID), ResultAction, req_ctx(ID, Seq), mg_utils:default_deadline())
         end
     catch
-        throw:machine_failed          -> failed;
-        throw:machine_already_exist   -> already_exist;
-        throw:machine_not_found       -> not_found;
-        throw:machine_already_working -> already_working
+        throw:{logic, machine_failed         } -> failed;
+        throw:{logic, machine_already_exist  } -> already_exist;
+        throw:{logic, machine_not_found      } -> not_found;
+        throw:{logic, machine_already_working} -> already_working
     end.
 
 -spec req_ctx(id(), seq()) ->

--- a/apps/mg_woody_api/src/mg_woody_api_automaton.erl
+++ b/apps/mg_woody_api/src/mg_woody_api_automaton.erl
@@ -145,7 +145,7 @@ get_ns_options(Namespace, Options) ->
         maps:get(Namespace, Options)
     catch
         error:{badkey, Namespace} ->
-            throw(namespace_not_found)
+            throw({logic, namespace_not_found})
     end.
 
 -spec logger(mg:ns(), options()) ->

--- a/apps/mg_woody_api/src/mg_woody_api_event_sink.erl
+++ b/apps/mg_woody_api/src/mg_woody_api_event_sink.erl
@@ -63,7 +63,7 @@ check_event_sink(AvaliableEventSinks, EventSinkID) ->
         true ->
             ok;
         false ->
-            throw(event_sink_not_found)
+            throw({logic, event_sink_not_found})
     end.
 
 -spec logger(mg_events_sink:options()) ->

--- a/apps/mg_woody_api/src/mg_woody_api_logger.erl
+++ b/apps/mg_woody_api/src/mg_woody_api_logger.erl
@@ -52,6 +52,9 @@ format_event(Subj, {machine_event, SubjID, ReqCtx, MachineEvent}) ->
 
 -spec format_request_event(mg_machine_logger:request_event()) ->
     log_msg().
+format_request_event({request_failed, Exception={throw, {logic, _}, _}}) ->
+    % бизнес ошибки это не warning
+    {info, {"request handling failed ~p", [Exception]}, []};
 format_request_event({request_failed, Exception}) ->
     {warning, {"request handling failed ~p", [Exception]}, []};
 format_request_event({timer_handling_failed, Exception}) ->

--- a/apps/mg_woody_api/src/mg_woody_api_utils.erl
+++ b/apps/mg_woody_api/src/mg_woody_api_utils.erl
@@ -61,14 +61,14 @@ handle_safe_with_retry_(Ref, ReqCtx, F, Retry, Logger) ->
         end
     end.
 
--spec handle_error(mg_machine:thrown_error() | namespace_not_found, {wait, _, _} | finish) ->
+-spec handle_error(mg_machine:thrown_error() | {logic, namespace_not_found}, {wait, _, _} | finish) ->
     {rethrow, _} | {woody_error, {woody_error:class(), _Details}} | {retry_in, pos_integer(), genlib_retry:strategy()}.
-handle_error(machine_not_found      , _) -> {rethrow, #'MachineNotFound'      {}};
-handle_error(machine_already_exist  , _) -> {rethrow, #'MachineAlreadyExists' {}};
-handle_error(machine_failed         , _) -> {rethrow, #'MachineFailed'        {}};
-handle_error(machine_already_working, _) -> {rethrow, #'MachineAlreadyWorking'{}};
-handle_error(namespace_not_found    , _) -> {rethrow, #'NamespaceNotFound'    {}};
-handle_error(event_sink_not_found   , _) -> {rethrow, #'EventSinkNotFound'    {}};
+handle_error({logic, machine_not_found      }, _) -> {rethrow, #'MachineNotFound'      {}};
+handle_error({logic, machine_already_exist  }, _) -> {rethrow, #'MachineAlreadyExists' {}};
+handle_error({logic, machine_failed         }, _) -> {rethrow, #'MachineFailed'        {}};
+handle_error({logic, machine_already_working}, _) -> {rethrow, #'MachineAlreadyWorking'{}};
+handle_error({logic, namespace_not_found    }, _) -> {rethrow, #'NamespaceNotFound'    {}};
+handle_error({logic, event_sink_not_found   }, _) -> {rethrow, #'EventSinkNotFound'    {}};
 
 % может Reason не прокидывать дальше?
 % TODO logs


### PR DESCRIPTION
Убрал бизнес логические ошибки с уровня warning на уровень info, чтобы не засирали мониторинги. Посмотрите кто-нить, кому не лень, чтобы сами знаете кого не отвлекать.