### PR TITLE
Fix `default_processing_timeout` parsing in event_sink config

### DIFF
--- a/rel_scripts/configurator.escript
+++ b/rel_scripts/configurator.escript
@@ -203,7 +203,7 @@ event_sink_ns(YamlConfig) ->
     #{
         storage                    => storage(<<"_event_sinks">>, YamlConfig),
         duplicate_search_batch     => 1000,
-        default_processing_timeout => ?C:time_interval("30S")
+        default_processing_timeout => ?C:time_interval("30S", ms)
     }.
 
 %%


### PR DESCRIPTION
Oops