### PR TITLE
MG-126 Add timers retry

### DIFF
--- a/apps/mg/src/mg_machine.erl
+++ b/apps/mg/src/mg_machine.erl
@@ -310,7 +310,7 @@ reply(#{call_context := CallContext}, Reply) ->
 %%
 -define(DEFAULT_SCHEDULED_TASK, disable). % {1000, 10}
 -define(DEFAULT_RETRY_POLICY, {exponential, infinity, 2, 10, 60 * 1000}).
--define(DEFAULT_TIMER_TIMEOUT, 60000).
+-define(DEFAULT_TIMER_PROCESSING_TIMEOUT, 60000).
 -define(DEFAULT_RESCHEDULING_TIMEOUT, 60000).
 
 -define(safe_request(Options, ID, ReqCtx, EventTag, Expr),
@@ -351,7 +351,7 @@ handle_timer(Options, ID, TimerTs) ->
                 % Важный момент, что если не проверить соответствие таймстемпов, то будет рейс
                 % когда по старому индексу вычитается новый таймер и сработает не вовремя!
                 #{status := {waiting, Timestamp, ReqCtx, _Timeout}} when Timestamp =:= TimerTs ->
-                    Timeout = maps:get(timer_processing_timeout, Options, ?DEFAULT_TIMER_TIMEOUT),
+                    Timeout = maps:get(timer_processing_timeout, Options, ?DEFAULT_TIMER_PROCESSING_TIMEOUT),
                     handle_timer(Options, ID, Timestamp, ReqCtx, mg_utils:timeout_to_deadline(Timeout));
                 #{status := _} ->
                     ok
@@ -405,7 +405,7 @@ handle_timer_retry(Options, ID, TimerTs) ->
                 % Важный момент, что если не проверить соответствие таймстемпов, то будет рейс
                 % когда по старому индексу вычитается новый таймер и сработает не вовремя!
                 #{status := {retrying, Timestamp, _Start, _Attempt, ReqCtx}} when Timestamp =:= TimerTs ->
-                    Timeout = maps:get(timer_processing_timeout, Options, ?DEFAULT_TIMER_TIMEOUT),
+                    Timeout = maps:get(timer_processing_timeout, Options, ?DEFAULT_TIMER_PROCESSING_TIMEOUT),
                     handle_timer_retry(Options, ID, Timestamp, ReqCtx, mg_utils:timeout_to_deadline(Timeout));
                 #{status := _} ->
                     ok

--- a/apps/mg/src/mg_machine.erl
+++ b/apps/mg/src/mg_machine.erl
@@ -32,12 +32,16 @@
 %%    - машина не найдена -- machine_not_found
 %%    - машина уже существует -- machine_already_exist
 %%    - машина находится в упавшем состоянии -- machine_failed
+%%    - некорректная попытка повторно запланировать обработку события -- invalid_reshedule_request
 %%    - что-то ещё?
 %%   - временные -- transient
 %%    - сервис перегружен —- overload
-%%    - хранилище недоступно -- {storage_unavailable  , Details}
+%%    - хранилище недоступно -- {storage_unavailable, Details}
 %%    - процессор недоступен -- {processor_unavailable, Details}
+%%    - исчерпаны попытки повтора -- {retries_exhausted, Error}
 %%   - таймауты -- {timeout, Details}
+%%   - окончательные -- permanent
+%%    - исчерпаны попытки повтора обработки таймера -- timer_retries_exhausted
 %%  - неожиданные
 %%   - что-то пошло не так -- падение с любой другой ошибкой
 %%
@@ -88,6 +92,7 @@
 
 %% Internal API
 -export([handle_timers         /2]).
+-export([handle_timers_retries /2]).
 -export([resume_interrupted    /2]).
 -export([resume_interrupted_one/2]).
 -export([all_statuses          /0]).
@@ -102,24 +107,27 @@
 %% API
 %%
 -type scheduled_task_opt() :: disable | #{interval => pos_integer(), limit => mg_storage:index_limit()}.
+-type retry_subj() :: storage | processor | timers.
 -type retry_opt() :: #{
-    storage   => mg_utils:genlib_retry_policy(),
-    processor => mg_utils:genlib_retry_policy()
+    retry_subj()   => mg_retry:policy()
 }.
 -type scheduled_tasks_opt() :: #{
-    timers   => scheduled_task_opt(),
-    overseer => scheduled_task_opt()
+    timers           => scheduled_task_opt(),
+    timers_retries   => scheduled_task_opt(),
+    overseer         => scheduled_task_opt()
 }.
 -type suicide_probability() :: float() | integer() | undefined. % [0, 1]
 
 -type options() :: #{
-    namespace           => mg:ns(),
-    storage             => mg_storage:options(),
-    processor           => mg_utils:mod_opts(),
-    logger              => mg_machine_logger:handler(),
-    retries             => retry_opt(),
-    scheduled_tasks     => scheduled_tasks_opt(),
-    suicide_probability => suicide_probability()
+    namespace                => mg:ns(),
+    storage                  => mg_storage:options(),
+    processor                => mg_utils:mod_opts(),
+    logger                   => mg_machine_logger:handler(),
+    retries                  => retry_opt(),
+    scheduled_tasks          => scheduled_tasks_opt(),
+    suicide_probability      => suicide_probability(),
+    reshedule_timeout        => timeout(),
+    timer_processing_timeout => timeout()
 }.
 
 -type thrown_error() :: {logic, logic_error()} | {transient, transient_error()} | {timeout, _Reason}.
@@ -132,6 +140,7 @@
 -type machine_regular_status() ::
        sleeping
     | {waiting, genlib_time:ts(), request_context(), HandlingTimeout::pos_integer()}
+    | {retrying, Target::genlib_time:ts(), Start::genlib_time:ts(), Attempt::non_neg_integer(), request_context()}
     | {processing, request_context()}
 .
 -type machine_status() :: machine_regular_status() | {error, Reason::term(), machine_regular_status()}.
@@ -178,6 +187,8 @@
        sleeping
     |  waiting
     | {waiting, From::genlib_time:ts(), To::genlib_time:ts()}
+    |  retrying
+    | {retrying, From::genlib_time:ts(), To::genlib_time:ts()}
     |  processing
     |  failed
 .
@@ -202,8 +213,9 @@ start_link(Options) ->
         mg_utils:lists_compact([
             mg_workers_manager:child_spec(manager_options(Options), manager),
             mg_storage        :child_spec(storage_options(Options), storage, storage_reg_name(Options)),
-            scheduler_child_spec(timers  , Options),
-            scheduler_child_spec(overseer, Options),
+            scheduler_child_spec(timers        , Options),
+            scheduler_child_spec(timers_retries, Options),
+            scheduler_child_spec(overseer      , Options),
             processor_child_spec(Options)
         ])
     ).
@@ -298,6 +310,8 @@ reply(#{call_context := CallContext}, Reply) ->
 %%
 -define(DEFAULT_SCHEDULED_TASK, disable). % {1000, 10}
 -define(DEFAULT_RETRY_POLICY, {exponential, infinity, 2, 10, 60 * 1000}).
+-define(DEFAULT_TIMER_TIMEOUT, 60000).
+-define(DEFAULT_RESCHEDULING_TIMEOUT, 60000).
 
 -define(safe_request(Options, ID, ReqCtx, EventTag, Expr),
     try
@@ -307,6 +321,7 @@ reply(#{call_context := CallContext}, Reply) ->
         ok = emit_log_request_event(Options, ID, ReqCtx, Event)
     end
 ).
+-define(can_be_retried(ErrorType), ErrorType =:= transient orelse ErrorType =:= timeout).
 
 -spec handle_timers(options(), mg_storage:index_limit()) ->
     ok.
@@ -335,7 +350,8 @@ handle_timer(Options, ID, TimerTs) ->
             case StorageMachine of
                 % Важный момент, что если не проверить соответствие таймстемпов, то будет рейс
                 % когда по старому индексу вычитается новый таймер и сработает не вовремя!
-                #{status := {waiting, Timestamp, ReqCtx, Timeout}} when Timestamp =:= TimerTs ->
+                #{status := {waiting, Timestamp, ReqCtx, _Timeout}} when Timestamp =:= TimerTs ->
+                    Timeout = maps:get(timer_processing_timeout, Options, ?DEFAULT_TIMER_TIMEOUT),
                     handle_timer(Options, ID, Timestamp, ReqCtx, mg_utils:timeout_to_deadline(Timeout));
                 #{status := _} ->
                     ok
@@ -353,7 +369,64 @@ handle_timer(Options, ID, Timestamp, ReqCtx, Deadline) ->
             CallQueue = mg_workers_manager:get_call_queue(manager_options(Options), ID),
             case lists:member(Call, CallQueue) of
                 false ->
-                    call_(Options, ID, Call, ReqCtx, Deadline);
+                    RescheduleTimeout = maps:get(reshedule_timeout, Options, ?DEFAULT_RESCHEDULING_TIMEOUT),
+                    RescheduleCall = {retry_wait, {waiting, Timestamp}},
+                    call_with_reschedule(Options, ID, Call, ReqCtx, Deadline, RescheduleCall, RescheduleTimeout);
+                true ->
+                    ok
+            end
+        end
+    ).
+
+-spec handle_timers_retries(options(), mg_storage:index_limit()) ->
+    ok.
+handle_timers_retries(Options, Limit) ->
+    ?safe_request(
+        Options, undefined, null, timer_retry_handling_failed,
+        begin
+            {Timers, _} = search(Options, {retrying, 1, genlib_time:now()}, Limit),
+            lists:foreach(
+                fun({Ts, ID}) ->
+                    erlang:spawn_link(fun() -> handle_timer_retry(Options, ID, Ts) end)
+                end,
+                Timers
+            )
+        end
+    ).
+
+-spec handle_timer_retry(options(), mg:id(), genlib_time:ts()) ->
+    ok.
+handle_timer_retry(Options, ID, TimerTs) ->
+    ?safe_request(
+        Options, ID, null, timer_retry_handling_failed,
+        begin
+            {_, StorageMachine} = get_storage_machine(Options, ID),
+            case StorageMachine of
+                % Важный момент, что если не проверить соответствие таймстемпов, то будет рейс
+                % когда по старому индексу вычитается новый таймер и сработает не вовремя!
+                #{status := {retrying, Timestamp, _Start, _Attempt, ReqCtx}} when Timestamp =:= TimerTs ->
+                    Timeout = maps:get(timer_processing_timeout, Options, ?DEFAULT_TIMER_TIMEOUT),
+                    handle_timer_retry(Options, ID, Timestamp, ReqCtx, mg_utils:timeout_to_deadline(Timeout));
+                #{status := _} ->
+                    ok
+            end
+        end
+    ).
+
+
+-spec handle_timer_retry(options(), mg:id(), genlib_time:ts(), request_context(), mg_utils:deadline()) ->
+    ok.
+handle_timer_retry(Options, ID, Timestamp, ReqCtx, Deadline) ->
+    ?safe_request(
+        Options, ID, ReqCtx, timer_retry_handling_failed,
+        begin
+            Call = {timeout, Timestamp},
+            CallQueue = mg_workers_manager:get_call_queue(manager_options(Options), ID),
+            case lists:member(Call, CallQueue) of
+                false ->
+                    RescheduleTimeout = maps:get(reshedule_timeout, Options, ?DEFAULT_RESCHEDULING_TIMEOUT),
+                    RescheduleCall = {retry_wait, {retrying, Timestamp}},
+                    call_with_reschedule(Options, ID, Call, ReqCtx, Deadline, RescheduleCall, RescheduleTimeout);
                 true ->
                     ok
             end
@@ -413,12 +486,22 @@ resume_interrupted_one(Options, ID, ReqCtx, Deadline) ->
 -spec all_statuses() ->
     [atom()].
 all_statuses() ->
-    [sleeping, waiting, processing, failed].
+    [sleeping, waiting, retrying, processing, failed].
 
 -spec call_(options(), mg:id(), _, request_context(), mg_utils:deadline()) ->
     _ | no_return().
 call_(Options, ID, Call, ReqCtx, Deadline) ->
     mg_utils:throw_if_error(mg_workers_manager:call(manager_options(Options), ID, Call, ReqCtx, Deadline)).
+
+-spec call_with_reschedule(options(), mg:id(), _, request_context(), mg_utils:deadline(), _, timeout()) ->
+    _ | no_return().
+call_with_reschedule(Options, ID, Call, ReqCtx, CallDeadline, RescheduleCall, RescheduleTimeout) ->
+    case mg_workers_manager:call(manager_options(Options), ID, Call, ReqCtx, CallDeadline) of
+        {error, {ErrorType, _Details}} when ?can_be_retried(ErrorType) ->
+            call_(Options, ID, RescheduleCall, ReqCtx, mg_utils:timeout_to_deadline(RescheduleTimeout));
+        Result ->
+            mg_utils:throw_if_error(Result)
+    end.
 
 %%
 %% mg_worker callbacks
@@ -488,6 +571,8 @@ handle_call(Call, CallContext, ReqCtx, Deadline, S=#{storage_machine:=StorageMac
             {noreply, process({call, SubCall}, PCtx, ReqCtx, Deadline, S)};
         {{call  , SubCall}, #{status:={waiting, _, _, _}}} ->
             {noreply, process({call, SubCall}, PCtx, ReqCtx, Deadline, S)};
+        {{call  , SubCall}, #{status:={retrying, _, _, _, _}}} ->
+            {noreply, process({call, SubCall}, PCtx, ReqCtx, Deadline, S)};
         {{call  , _      }, #{status:={error  , _, _   }}} -> {{reply, {error, {logic, machine_failed}}}, S};
 
         % repair
@@ -502,8 +587,20 @@ handle_call(Call, CallContext, ReqCtx, Deadline, S=#{storage_machine:=StorageMac
         {{timeout, Ts0}, #{status:={waiting, Ts1, _, _}}}
             when Ts0 =:= Ts1 ->
             {noreply, process(timeout, PCtx, ReqCtx, Deadline, S)};
+        {{timeout, Ts0}, #{status:={retrying, Ts1, _, _, _}}}
+            when Ts0 =:= Ts1 ->
+            {noreply, process(timeout, PCtx, ReqCtx, Deadline, S)};
         {{timeout, _}, #{status:=_}} ->
-            {{reply, {ok, ok}}, S}
+            {{reply, {ok, ok}}, S};
+
+        {{retry_wait, {waiting, Ts0}}, #{status:={waiting, Ts1, _, _}}}
+            when Ts0 =:= Ts1 ->
+            {noreply, reshedule(PCtx, ReqCtx, Deadline, S)};
+        {{retry_wait, {retrying, Ts0}}, #{status:={retrying, Ts1, _, _, _}}}
+            when Ts0 =:= Ts1 ->
+            {noreply, reshedule(PCtx, ReqCtx, Deadline, S)};
+        {{retry_wait, _}, #{status:=_}} ->
+            {{reply, {error, {logic, invalid_reshedule_request}}}, S}
     end.
 
 -spec handle_unload(state()) ->
@@ -565,7 +662,8 @@ machine_status_to_opaque(Status) ->
             {waiting, TS, ReqCtx, HdlTo} -> [2, TS, ReqCtx, HdlTo];
             {processing, ReqCtx}         -> [3, ReqCtx];
             % TODO подумать как упаковывать reason
-            {error, Reason, OldStatus}   -> [4, erlang:term_to_binary(Reason), machine_status_to_opaque(OldStatus)]
+            {error, Reason, OldStatus}   -> [4, erlang:term_to_binary(Reason), machine_status_to_opaque(OldStatus)];
+            {retrying, TS, StartTS, Attempt, ReqCtx} -> [5, TS, StartTS, Attempt, ReqCtx]
         end,
     Opaque.
 
@@ -580,7 +678,8 @@ opaque_to_machine_status(Opaque) ->
         [3, ReqCtx           ] -> {processing, ReqCtx};
         [4, Reason, OldStatus] -> {error, erlang:binary_to_term(Reason), opaque_to_machine_status(OldStatus)};
         % устаревшее
-        [4, Reason           ] -> {error, erlang:binary_to_term(Reason), sleeping}
+        [4, Reason           ] -> {error, erlang:binary_to_term(Reason), sleeping};
+        [5, TS, StartTS, Attempt, ReqCtx] -> {retrying, TS, StartTS, Attempt, ReqCtx}
     end.
 
 
@@ -589,6 +688,7 @@ opaque_to_machine_status(Opaque) ->
 %%
 -define(status_idx , {integer, <<"status"      >>}).
 -define(waiting_idx, {integer, <<"waiting_date">>}).
+-define(retrying_idx, {integer, <<"retrying_date">>}).
 
 -spec storage_search_query(search_query(), mg_storage:index_limit()) ->
     mg_storage:index_query().
@@ -606,30 +706,37 @@ storage_search_query({waiting, FromTs, ToTs}) ->
 storage_search_query(processing) ->
     {?status_idx, 3};
 storage_search_query(failed) ->
-    {?status_idx, 4}.
+    {?status_idx, 4};
+storage_search_query(retrying) ->
+    {?status_idx, 5};
+storage_search_query({retrying, FromTs, ToTs}) ->
+    {?retrying_idx, {FromTs, ToTs}}.
 
 -spec storage_machine_to_indexes(storage_machine()) ->
     [mg_storage:index_update()].
 storage_machine_to_indexes(#{status := Status}) ->
-    status_index(Status) ++ waiting_date_index(Status).
+    status_index(Status) ++ status_range_index(Status).
 
 -spec status_index(machine_status()) ->
     [mg_storage:index_update()].
 status_index(Status) ->
     StatusInt =
         case Status of
-             sleeping             -> 1;
-            {waiting   , _, _, _} -> 2;
-            {processing, _      } -> 3;
-            {error     , _, _   } -> 4
+             sleeping                -> 1;
+            {waiting   , _, _, _   } -> 2;
+            {processing, _         } -> 3;
+            {error     , _, _      } -> 4;
+            {retrying  , _, _, _, _} -> 5
         end,
     [{?status_idx, StatusInt}].
 
--spec waiting_date_index(machine_status()) ->
+-spec status_range_index(machine_status()) ->
     [mg_storage:index_update()].
-waiting_date_index({waiting, Timestamp, _, _}) ->
+status_range_index({waiting, Timestamp, _, _}) ->
     [{?waiting_idx, Timestamp}];
-waiting_date_index(_) ->
+status_range_index({retrying, Timestamp, _, _, _}) ->
+    [{?retrying_idx, Timestamp}];
+status_range_index(_) ->
     [].
 
 %%
@@ -656,9 +763,13 @@ process_simple_repair(ReqCtx, Deadline, State) ->
 process(Impact, ProcessingCtx, ReqCtx, Deadline, State) ->
     try
         process_unsafe(Impact, ProcessingCtx, ReqCtx, Deadline, State)
-    catch Class:Reason ->
-        ok = do_reply_action({reply, {error, {logic, machine_failed}}}, ProcessingCtx),
-        handle_exception({Class, Reason, erlang:get_stacktrace()}, Impact, ReqCtx, Deadline, State)
+    catch
+        throw:(Reason=({ErrorType, _Details})) when ?can_be_retried(ErrorType) ->
+            ok = do_reply_action({reply, {error, Reason}}, ProcessingCtx),
+            State;
+        Class:Reason ->
+            ok = do_reply_action({reply, {error, {logic, machine_failed}}}, ProcessingCtx),
+            handle_exception({Class, Reason, erlang:get_stacktrace()}, Impact, ReqCtx, Deadline, State)
     end.
 
 -spec handle_exception(Exception, Impact, ReqCtx, Deadline, state()) -> state() when
@@ -732,6 +843,59 @@ processor_process_machine(ID, Impact, ProcessingCtx, ReqCtx, Deadline, MachineSt
 processor_child_spec(Options) ->
     mg_utils:apply_mod_opts_if_defined(get_options(processor, Options), processor_child_spec, undefined).
 
+-spec reshedule(ProcessingCtx, ReqCtx, Deadline, state()) -> state() when
+    ProcessingCtx :: processing_context(),
+    ReqCtx :: request_context(),
+    Deadline :: mg_utils:deadline().
+reshedule(ProcessingCtx, ReqCtx, Deadline, State) ->
+    try
+        reshedule_unsafe(ReqCtx, Deadline, State)
+    catch
+        throw:(Reason=({ErrorType, _Details})) when ?can_be_retried(ErrorType) ->
+            ok = do_reply_action({reply, {error, Reason}}, ProcessingCtx),
+            State;
+        Class:Reason ->
+            ok = do_reply_action({reply, {error, {logic, machine_failed}}}, ProcessingCtx),
+            handle_exception({Class, Reason, erlang:get_stacktrace()}, undefined, ReqCtx, Deadline, State)
+    end.
+
+-spec reshedule_unsafe(ReqCtx, Deadline, state()) -> state() when
+    ReqCtx :: request_context(),
+    Deadline :: mg_utils:deadline().
+reshedule_unsafe(ReqCtx, Deadline, State) ->
+    #{storage_machine := #{status := MachineStatus}} = State,
+    reshedule_unsafe(MachineStatus, ReqCtx, Deadline, State).
+
+-spec reshedule_unsafe(MachineStatus, ReqCtx, Deadline, state()) -> state() when
+    ReqCtx :: request_context(),
+    Deadline :: mg_utils:deadline(),
+    MachineStatus :: machine_regular_status().
+reshedule_unsafe({waiting, _, _, _}, ReqCtx, Deadline, State) ->
+    #{storage_machine := StorageMachine, options := Options} = State,
+    RetryStrategy = retry_strategy(timers, Options, undefined),
+    case genlib_retry:next_step(RetryStrategy) of
+        {wait, Timeout, _NewRetryStrategy} ->
+            Now = genlib_time:now(),
+            NewStatus = {retrying, Now + Timeout, Now, 0, ReqCtx},
+            NewStorageMachine = StorageMachine#{status => NewStatus},
+            transit_state(ReqCtx, Deadline, NewStorageMachine, State);
+        finish ->
+            throw({permanent, timer_retries_exhausted})
+    end;
+reshedule_unsafe({retrying, _, Start, Attempt, _}, ReqCtx, Deadline, State) ->
+    #{storage_machine := StorageMachine, options := Options} = State,
+    RetryStrategy = retry_strategy(timers, Options, undefined, Start, Attempt),
+    case genlib_retry:next_step(RetryStrategy) of
+        {wait, Timeout, _NewRetryStrategy} ->
+            Now = genlib_time:now(),
+            NewStatus = {retrying, Now + Timeout, Start, Attempt + 1, ReqCtx},
+            NewStorageMachine = StorageMachine#{status => NewStatus},
+            transit_state(ReqCtx, Deadline, NewStorageMachine, State);
+        finish ->
+            throw({permanent, timer_retries_exhausted})
+    end.
+
+
 -spec do_reply_action(processor_reply_action(), undefined | processing_context()) ->
     ok.
 do_reply_action(noreply, _) ->
@@ -786,20 +950,33 @@ remove_from_storage(ReqCtx, Deadline, State = #{id := ID, options := Options, st
     ok = do_with_retry(Options, ID, F, retry_strategy(storage, Options, Deadline), ReqCtx),
     State#{storage_machine := undefined, storage_context := undefined}.
 
--spec retry_strategy(storage | processor, options(), mg_utils:deadline()) ->
-    genlib_retry:strategy().
+-spec retry_strategy(retry_subj(), options(), mg_utils:deadline()) ->
+    mg_retry:strategy().
 retry_strategy(Subj, Options, Deadline) ->
+    retry_strategy(Subj, Options, Deadline, undefined, undefined).
+
+-spec retry_strategy(Subj, Options, Deadline, InitialTs, Attempt) -> mg_retry:strategy() when
+    Subj :: retry_subj(),
+    Options :: options(),
+    Deadline :: mg_utils:deadline(),
+    InitialTs :: genlib_time:ts() | undefined,
+    Attempt :: non_neg_integer() | undefined.
+retry_strategy(Subj, Options, Deadline, InitialTs, Attempt) ->
     Retries = maps:get(retries, Options, #{}),
     Policy = maps:get(Subj, Retries, ?DEFAULT_RETRY_POLICY),
-    retry_strategy_(Subj, Policy, Deadline).
+    retry_strategy_(Subj, Policy, Deadline, InitialTs, Attempt).
 
--spec retry_strategy_(storage | processor, mg_utils:genlib_retry_policy(), mg_utils:deadline()) ->
-    genlib_retry:strategy().
-retry_strategy_(storage, Policy, _Deadline) ->
-    mg_utils:genlib_retry_new(Policy);
-retry_strategy_(_Subj, Policy, Deadline) ->
+-spec retry_strategy_(Subj, Policy, Deadline, InitialTs, Attempt) -> mg_retry:strategy() when
+    Subj :: retry_subj(),
+    Policy :: mg_retry:policy(),
+    Deadline :: mg_utils:deadline(),
+    InitialTs :: genlib_time:ts() | undefined,
+    Attempt :: non_neg_integer() | undefined.
+retry_strategy_(storage, Policy, _Deadline, InitialTs, Attempt) ->
+    mg_retry:new_strategy(Policy, InitialTs, Attempt);
+retry_strategy_(_Subj, Policy, Deadline, InitialTs, Attempt) ->
     Timeout = mg_utils:deadline_to_timeout(Deadline),
-    mg_utils:genlib_retry_new({timecap, Timeout, Policy}).
+    mg_retry:new_strategy({timecap, Timeout, Policy}, InitialTs, Attempt).
 
 %%
 
@@ -841,8 +1018,9 @@ scheduler_child_spec(Task, Options) ->
             undefined;
         #{interval := Interval, limit := Limit} ->
             F = case Task of
-                    timers   -> handle_timers;
-                    overseer -> resume_interrupted
+                    timers         -> handle_timers;
+                    timers_retries -> handle_timers_retries;
+                    overseer       -> resume_interrupted
                 end,
             mg_cron:child_spec(#{interval => Interval, job => {?MODULE, F, [Options, Limit]}}, Task)
     end.
@@ -868,7 +1046,7 @@ try_suicide(#{}, _) ->
 %%
 %% retrying
 %%
--spec do_with_retry(options(), mg:id(), fun(() -> R), genlib_retry:strategy(), request_context()) ->
+-spec do_with_retry(options(), mg:id(), fun(() -> R), mg_retry:strategy(), request_context()) ->
     R.
 do_with_retry(Options, ID, Fun, RetryStrategy, ReqCtx) ->
     try
@@ -881,7 +1059,7 @@ do_with_retry(Options, ID, Fun, RetryStrategy, ReqCtx) ->
                 ok = timer:sleep(Timeout),
                 do_with_retry(Options, ID, Fun, NewRetryStrategy, ReqCtx);
             finish ->
-                throw({timeout, {retry_timeout, Reason}})
+                throw({transient, {retries_exhausted, Reason}})
         end
     end.
 

--- a/apps/mg/src/mg_machine_logger.erl
+++ b/apps/mg/src/mg_machine_logger.erl
@@ -31,8 +31,9 @@
     | {machine_event, mg:id(), mg:request_context(), machine_event()}
 .
 -type request_event() ::
-      {request_failed             , mg_utils:exception()}  % ошибка при обработки внешнего запроса
-    | {timer_handling_failed      , mg_utils:exception()}  % ошибка при обработки таймера
+      {request_failed             , mg_utils:exception()}  % ошибка при обработке внешнего запроса
+    | {timer_handling_failed      , mg_utils:exception()}  % ошибка при обработке таймера
+    | {timer_retry_handling_failed, mg_utils:exception()}  % ошибка при повторной обработке таймера
     | {resuming_interrupted_failed, mg_utils:exception()}  % ошибка при переподнятии машины
     | {retrying                   , Delay::pos_integer()}
 .

--- a/apps/mg/src/mg_retry.erl
+++ b/apps/mg/src/mg_retry.erl
@@ -1,0 +1,78 @@
+%%%
+%%% Copyright 2018 RBKmoney
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%
+
+%%%
+%%% Retry helpers.
+%%% TODO: Move to genlib_retry
+%%%
+-module(mg_retry).
+
+-export_type([policy/0]).
+-export_type([strategy/0]).
+-export([new_strategy/1]).
+-export([new_strategy/3]).
+
+-type retries_num() :: pos_integer() | infinity.
+-type policy() ::
+      {linear, retries_num() | {max_total_timeout, pos_integer()}, pos_integer()}
+    | {exponential, retries_num() | {max_total_timeout, pos_integer()}, number(), pos_integer()}
+    | {exponential, retries_num() | {max_total_timeout, pos_integer()}, number(), pos_integer(), timeout()}
+    | {intervals, [pos_integer(), ...]}
+    | {timecap, timeout(), policy()}
+.
+
+-type strategy() :: genlib_retry:strategy().
+
+%% API
+
+-spec new_strategy(policy()) ->
+    strategy().
+new_strategy({linear, Retries, Timeout}) ->
+    genlib_retry:linear(Retries, Timeout);
+new_strategy({exponential, Retries, Factor, Timeout}) ->
+    genlib_retry:exponential(Retries, Factor, Timeout);
+new_strategy({exponential, Retries, Factor, Timeout, MaxTimeout}) ->
+    genlib_retry:exponential(Retries, Factor, Timeout, MaxTimeout);
+new_strategy({intervals, Array}) ->
+    genlib_retry:intervals(Array);
+new_strategy({timecap, Timeout, Policy}) ->
+    genlib_retry:timecap(Timeout, new_strategy(Policy));
+new_strategy(BadPolicy) ->
+    erlang:error(badarg, [BadPolicy]).
+
+-spec new_strategy
+    (policy(), genlib_time:ts(), non_neg_integer()) -> strategy();
+    (policy(), undefined, undefined) -> strategy().
+new_strategy(PolicySpec, undefined, undefined) ->
+    new_strategy(PolicySpec);
+new_strategy(PolicySpec, _InitialTimestamp, Attempt) ->
+    %% TODO: Use InitialTimestamp
+    Strategy = new_strategy(PolicySpec),
+    skip_steps(Strategy, Attempt).
+
+%% Internals
+
+-spec skip_steps(strategy(), non_neg_integer()) -> strategy().
+skip_steps(Strategy, 0) ->
+    Strategy;
+skip_steps(Strategy, N) when N > 0 ->
+    NewStrategy = case genlib_retry:next_step(Strategy) of
+        {wait, _Timeout, NextStrategy} ->
+            NextStrategy;
+        finish = NextStrategy ->
+            NextStrategy
+    end,
+    skip_steps(NewStrategy, N - 1).

--- a/apps/mg/src/mg_utils.erl
+++ b/apps/mg/src/mg_utils.erl
@@ -80,9 +80,6 @@
 
 -export([join/2]).
 
--export_type([genlib_retry_policy/0]).
--export([genlib_retry_new/1]).
-
 -export([lists_compact/1]).
 -export([stop_wait_all/3]).
 
@@ -391,29 +388,6 @@ format_exception({Class, Reason, Stacktrace}) ->
 join(_    , []   ) -> [];
 join(_    , [H]  ) ->  H;
 join(Delim, [H|T]) -> [H, Delim, join(Delim, T)].
-
--type retries_num() :: pos_integer() | infinity.
--type genlib_retry_policy() ::
-      {linear, retries_num() | {max_total_timeout, pos_integer()}, pos_integer()}
-    | {exponential, retries_num() | {max_total_timeout, pos_integer()}, number(), pos_integer()}
-    | {exponential, retries_num() | {max_total_timeout, pos_integer()}, number(), pos_integer(), timeout()}
-    | {intervals, [pos_integer(), ...]}
-    | {timecap, timeout(), genlib_retry_policy()}
-.
--spec genlib_retry_new(genlib_retry_policy()) ->
-    genlib_retry:strategy().
-genlib_retry_new({linear, Retries, Timeout}) ->
-    genlib_retry:linear(Retries, Timeout);
-genlib_retry_new({exponential, Retries, Factor, Timeout}) ->
-    genlib_retry:exponential(Retries, Factor, Timeout);
-genlib_retry_new({exponential, Retries, Factor, Timeout, MaxTimeout}) ->
-    genlib_retry:exponential(Retries, Factor, Timeout, MaxTimeout);
-genlib_retry_new({intervals, Array}) ->
-    genlib_retry:intervals(Array);
-genlib_retry_new({timecap, Timeout, Policy}) ->
-    genlib_retry:timecap(Timeout, genlib_retry_new(Policy));
-genlib_retry_new(BadPolicy) ->
-    erlang:error(badarg, [BadPolicy]).
 
 -spec lists_compact(list(T)) ->
     list(T).

--- a/apps/mg/test/mg_machine_SUITE.erl
+++ b/apps/mg/test/mg_machine_SUITE.erl
@@ -169,8 +169,9 @@ automaton_options() ->
         storage   => mg_storage_memory,
         logger    => ?MODULE,
         scheduled_tasks => #{
-            timers   => #{ interval => 1000, limit => 10 },
-            overseer => #{ interval => 1000, limit => 10 }
+            timers         => #{ interval => 1000, limit => 10 },
+            timers_retries => #{ interval => 1000, limit => 10 },
+            overseer       => #{ interval => 1000, limit => 10 }
         }
     }.
 

--- a/apps/mg/test/mg_timer_retry_SUITE.erl
+++ b/apps/mg/test/mg_timer_retry_SUITE.erl
@@ -1,0 +1,198 @@
+%%%
+%%% Copyright 2018 RBKmoney
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%
+
+-module(mg_timer_retry_SUITE).
+-include_lib("common_test/include/ct.hrl").
+
+%% tests descriptions
+-export([all           /0]).
+-export([groups        /0]).
+-export([init_per_group/2]).
+-export([end_per_group /2]).
+-export([init_per_suite/1]).
+-export([end_per_suite /1]).
+
+%% tests
+-export([transient_fail/1]).
+-export([permament_fail/1]).
+
+%% mg_machine
+-behaviour(mg_machine).
+-export([pool_child_spec/2, process_machine/7]).
+
+-export([start/0]).
+
+%% logger
+-export([handle_machine_logging_event/2]).
+
+%%
+%% tests descriptions
+%%
+-type test_name () :: atom().
+-type group     () :: {Name :: atom(), Opts :: list(), [test_name()]}.
+-type config    () :: [{atom(), _}].
+
+-spec all() ->
+    [test_name()] | {group, atom()}.
+all() ->
+    [
+       {group, all}
+    ].
+
+-spec groups() ->
+    [group()].
+groups() ->
+    [
+       {all, [], [%[parallel, shuffle], [
+           transient_fail,
+           permament_fail
+       ]}
+    ].
+
+%%
+%% starting/stopping
+%%
+-spec init_per_suite(config()) ->
+    config().
+init_per_suite(C) ->
+    % dbg:tracer(), dbg:p(all, c),
+    % dbg:tpl({mg_machine, '_', '_'}, x),
+    Apps = genlib_app:start_application(mg),
+    [{apps, Apps} | C].
+
+-spec end_per_suite(config()) ->
+    ok.
+end_per_suite(C) ->
+    [application:stop(App) || App <- proplists:get_value(apps, C)].
+
+-spec init_per_group(GroupName :: atom(), config()) ->
+    config().
+init_per_group(_GroupName, C) ->
+    C.
+
+-spec end_per_group(GroupName :: atom(), config()) ->
+    ok.
+end_per_group(_GroupName, C) ->
+    C.
+
+%%
+%% tests
+%%
+-define(req_ctx, <<"req_ctx">>).
+
+-spec transient_fail(config()) ->
+    _.
+transient_fail(_C) ->
+    BinTestName = genlib:to_binary(transient_fail),
+    NS = BinTestName,
+    ID = BinTestName,
+    Options = automaton_options(NS, {intervals, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]}),
+    _  = start_automaton(Options),
+
+    ok = mg_machine:start(Options, ID, <<"normal">>, ?req_ctx, mg_utils:default_deadline()),
+    0  = mg_machine:call(Options, ID, get, ?req_ctx, mg_utils:default_deadline()),
+    ok = mg_machine:call(Options, ID, {set_mode, <<"failing">>}, ?req_ctx, mg_utils:default_deadline()),
+    ok = timer:sleep(3000),
+    0  = mg_machine:call(Options, ID, get, ?req_ctx, mg_utils:default_deadline()),
+    ok = mg_machine:call(Options, ID, {set_mode, <<"counting">>}, ?req_ctx, mg_utils:default_deadline()),
+    ok = timer:sleep(3000),
+    I  = mg_machine:call(Options, ID, get, ?req_ctx, mg_utils:default_deadline()),
+    true = I > 0,
+    ok.
+
+-spec permament_fail(config()) ->
+    _.
+permament_fail(_C) ->
+    BinTestName = genlib:to_binary(permament_fail),
+    NS = BinTestName,
+    ID = BinTestName,
+    Options = automaton_options(NS, {timecap, 0, {intervals, [1]}}),  % without retries
+    _  = start_automaton(Options),
+
+    ok = mg_machine:start(Options, ID, <<"normal">>, ?req_ctx, mg_utils:default_deadline()),
+    0  = mg_machine:call(Options, ID, get, ?req_ctx, mg_utils:default_deadline()),
+    ok = mg_machine:call(Options, ID, {set_mode, <<"failing">>}, ?req_ctx, mg_utils:default_deadline()),
+    ok = timer:sleep(3000),
+    {logic, machine_failed} = (catch mg_machine:call(Options, ID, get, ?req_ctx, mg_utils:default_deadline())),
+    ok.
+
+%%
+%% processor
+%%
+-spec pool_child_spec(_Options, atom()) ->
+    supervisor:child_spec().
+pool_child_spec(_Options, Name) ->
+    #{
+        id    => Name,
+        start => {?MODULE, start, []}
+    }.
+
+-spec process_machine(_Options, mg:id(), mg_machine:processor_impact(), _, _, _, mg_machine:machine_state()) ->
+    mg_machine:processor_result() | no_return().
+process_machine(_, _, {init, Mode}, _, ?req_ctx, _, null) ->
+    {{reply, ok}, build_timer(), [Mode, 0]};
+process_machine(_, _, {call, get}, _, ?req_ctx, _, [_Mode, Counter] = State) ->
+    {{reply, Counter}, build_timer(), State};
+process_machine(_, _, {call, {set_mode, NewMode}}, _, ?req_ctx, _, [_Mode, Counter]) ->
+    {{reply, ok}, build_timer(), [NewMode, Counter]};
+process_machine(_, _, timeout, _, ?req_ctx, _, [<<"normal">>, _Counter] = State) ->
+    {{reply, ok}, build_timer(), State};
+process_machine(_, _, timeout, _, ?req_ctx, _, [<<"counting">> = Mode, Counter]) ->
+    {{reply, ok}, build_timer(), [Mode, Counter + 1]};
+process_machine(_, _, timeout, _, ?req_ctx, _, [<<"failing">>, _Counter]) ->
+    erlang:throw({transient, oops}).
+
+%%
+%% utils
+%%
+-spec start()->
+    ignore.
+start() ->
+    ignore.
+
+-spec start_automaton(mg_machine:options()) ->
+    pid().
+start_automaton(Options) ->
+    mg_utils:throw_if_error(mg_machine:start_link(Options)).
+
+-spec automaton_options(mg:ns(), mg_retry:policy()) ->
+    mg_machine:options().
+automaton_options(NS, RetryPolicy) ->
+    #{
+        namespace => NS,
+        processor => ?MODULE,
+        storage   => mg_storage_memory,
+        logger    => ?MODULE,
+        retries   => #{
+            timers         => RetryPolicy,
+            processor      => {timecap, 0, {intervals, [1]}}  % without retries
+        },
+        scheduled_tasks => #{
+            timers         => #{ interval => 100, limit => 10 },
+            timers_retries => #{ interval => 100, limit => 10 },
+            overseer       => #{ interval => 100, limit => 10 }
+        }
+    }.
+
+-spec handle_machine_logging_event(_, mg_machine_logger:event()) ->
+    ok.
+handle_machine_logging_event(_, {NS, ID, ReqCtx, SubEvent}) ->
+    ct:pal("[~s:~s:~s] ~p", [NS, ID, ReqCtx, SubEvent]).
+
+-spec build_timer() ->
+    mg_machine:processor_flow_action().
+build_timer() ->
+    {wait, genlib_time:now() + 1, ?req_ctx, 5000}.

--- a/apps/mg_woody_api/src/mg_woody_api.erl
+++ b/apps/mg_woody_api/src/mg_woody_api.erl
@@ -186,13 +186,20 @@ tags_options(NS, #{retries := Retries, storage := Storage}) ->
 -spec machine_options(mg:ns(), events_machines()) ->
     mg_machine:options().
 machine_options(NS, Config) ->
-    #{retries := Retries, scheduled_tasks := STasks, storage := Storage} = Config,
-    #{
+    #{storage := Storage} = Config,
+    Options = maps:with(
+        [
+            retries,
+            scheduled_tasks,
+            reshedule_timeout,
+            timer_processing_timeout
+        ],
+        Config
+    ),
+    Options#{
         namespace           => NS,
         storage             => add_bucket_postfix(<<"machines">>, Storage),
         logger              => logger({machine, NS}),
-        retries             => Retries,
-        scheduled_tasks     => STasks,
         % TODO сделать аналогично в event_sink'е и тэгах
         suicide_probability => maps:get(suicide_probability, Config, undefined)
     }.

--- a/apps/mg_woody_api/src/mg_woody_api_logger.erl
+++ b/apps/mg_woody_api/src/mg_woody_api_logger.erl
@@ -59,6 +59,8 @@ format_request_event({request_failed, Exception}) ->
     {warning, {"request handling failed ~p", [Exception]}, []};
 format_request_event({timer_handling_failed, Exception}) ->
     {warning, {"timer handling failed ~p", [Exception]}, []};
+format_request_event({timer_retry_handling_failed, Exception}) ->
+    {warning, {"timer retry handling failed ~p", [Exception]}, []};
 format_request_event({resuming_interrupted_failed, Exception}) ->
     {warning, {"resuming interrupted failed ~p", [Exception]}, []};
 format_request_event({retrying, RetryTimeout}) ->

--- a/apps/mg_woody_api/test/mg_stress_SUITE.erl
+++ b/apps/mg_woody_api/test/mg_stress_SUITE.erl
@@ -71,7 +71,7 @@ init_per_suite(C) ->
         {automaton_options , #{
             url => "http://localhost:8022",
             ns => ?NS,
-            retry_strategy => mg_utils:genlib_retry_new({exponential, 5, 2, 1000})
+            retry_strategy => mg_retry:new_strategy({exponential, 5, 2, 1000})
         }},
         {event_sink_options, "http://localhost:8022"          },
         {processor_pid     , ProcessorPid                     }
@@ -100,8 +100,9 @@ mg_woody_api_config(_C) ->
                 },
                 default_processing_timeout => 5000,
                 scheduled_tasks => #{
-                    timers   => #{ interval => 100, limit => 10 },
-                    overseer => #{ interval => 100, limit => 10 }
+                    timers         => #{ interval => 100, limit => 10 },
+                    timers_retries => #{ interval => 100, limit => 10 },
+                    overseer       => #{ interval => 100, limit => 10 }
                 },
                 retries => #{},
                 event_sink => ?ES_ID

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,6 +42,8 @@ namespaces:
         # suicide_probability: 0.1
         event_sink: main_event_sink
         default_processing_timeout: 30s
+        timer_processing_timeout: 60s
+        reshedule_timeout: 60s
         processor:
             url: http://localhost:8022/processor
             pool_size: 50


### PR DESCRIPTION
Потенциально ломающие изменения:
- Машины больше не переходят в состояние `failed` при возникновении `transient` исключений
- Таймауты, заданные при установке таймеров теперь игнорируются. Вместо них используется значение из конфига.

Остальные изменения
- Второй планировщик для повторов таймеров.
- В конфиг добавлены опции `timer_processing_timeout` и `reshedule_timeout`
- Исправлено значение опции `{ns}.retries.processor`