### PR TITLE
MG-157: Continuation retry delays

### DIFF
--- a/apps/mg/src/mg_machine.erl
+++ b/apps/mg/src/mg_machine.erl
@@ -432,7 +432,7 @@ handle_call(Call, CallContext, ReqCtx, Deadline, S=#{options:=Options, storage_m
             % обработка машин в стейте processing идёт без дедлайна
             % машина должна либо упасть, либо перейти в другое состояние
             % MG-157: ретраим с задержкой
-            RetryStrategy = retry_strategy(continuation, Options, undefined), %@wip unsure about the subject name
+            RetryStrategy = retry_strategy(continuation, Options, undefined),
             S1 = process(continuation, undefined, ProcessingReqCtx, undefined, RetryStrategy, S),
             handle_call(Call, CallContext, ReqCtx, Deadline, S1);
 
@@ -653,7 +653,7 @@ process(Impact, ProcessingCtx, ReqCtx, Deadline, RetryStrat, State = #{id := ID,
         process_unsafe(Impact, ProcessingCtx, ReqCtx, Deadline, RetryStrat, try_init_state(Impact, State))
     catch
         throw:(Reason=({ErrorType, _Details})):ST when ?can_be_retried(ErrorType) ->
-            ok = emit_beat(Opts, #mg_machine_process_transient_error{ %@wip not the correct event now?
+            ok = emit_beat(Opts, #mg_machine_process_transient_error{
                 namespace = NS,
                 machine_id = ID,
                 exception = {throw, Reason, ST},

--- a/apps/mg/src/mg_machine.erl
+++ b/apps/mg/src/mg_machine.erl
@@ -678,7 +678,7 @@ try_process_retry(Impact, ProcessingCtx, ReqCtx, Deadline, RetryStrategy, State)
             ok = timer:sleep(Timeout),
             process(Impact, ProcessingCtx, ReqCtx, Deadline, NewRetryStrategy, State);
         finish ->
-            State
+            throw({permanent, process_retries_exhausted})
     end.
 
 -spec try_init_state(processor_impact(), state()) ->

--- a/apps/mg/src/mg_machine.erl
+++ b/apps/mg/src/mg_machine.erl
@@ -116,7 +116,7 @@
     limit        => mg_quota_worker:name(),
     share        => mg_quota:share()
 }.
--type retry_subj() :: storage | processor | timers | continuation.
+-type retry_subj() :: storage | processor | timers | {processor_impact, processor_impact()}.
 -type retry_opt() :: #{
     retry_subj()   => mg_retry:policy()
 }.
@@ -201,8 +201,6 @@
     |  processing
     |  failed
 .
-
--type process_retry_strategy() :: mg_retry:strategy() | undefined.
 
 %%
 
@@ -371,7 +369,8 @@ call_(Options, ID, Call, ReqCtx, Deadline) ->
     namespace       => mg:ns(),
     options         => options(),
     storage_machine => storage_machine() | undefined,
-    storage_context => mg_storage:context() | undefined
+    storage_context => mg_storage:context() | undefined,
+    retry_strategy  => mg_retry:strategy()
 }.
 
 -type storage_machine() :: #{
@@ -413,7 +412,7 @@ handle_load(ID, Options, ReqCtx) ->
 
 -spec handle_call(_Call, mg_worker:call_context(), request_context(), mg_utils:deadline(), state()) ->
     {{reply, _Resp} | noreply, state()}.
-handle_call(Call, CallContext, ReqCtx, Deadline, S=#{options:=Options, storage_machine:=StorageMachine}) ->
+handle_call(Call, CallContext, ReqCtx, Deadline, S=#{storage_machine:=StorageMachine}) ->
     PCtx = new_processing_context(CallContext),
 
     % довольно сложное место, тут определяется приоритет реакции на внешние раздражители, нужно быть аккуратнее
@@ -431,9 +430,7 @@ handle_call(Call, CallContext, ReqCtx, Deadline, S=#{options:=Options, storage_m
         {_, #{status := {processing, ProcessingReqCtx}}} ->
             % обработка машин в стейте processing идёт без дедлайна
             % машина должна либо упасть, либо перейти в другое состояние
-            % MG-157: ретраим с задержкой
-            RetryStrategy = retry_strategy(continuation, Options, undefined),
-            S1 = process(continuation, undefined, ProcessingReqCtx, undefined, RetryStrategy, S),
+            S1 = process(continuation, undefined, ProcessingReqCtx, undefined, S),
             handle_call(Call, CallContext, ReqCtx, Deadline, S1);
 
         % ничего не просходит, просто убеждаемся, что машина загружена
@@ -641,16 +638,10 @@ process_simple_repair(ReqCtx, Deadline, State) ->
 
 -spec process(processor_impact(), processing_context(), request_context(), mg_utils:deadline(), state()) ->
     state().
-process(Impact, ProcessingCtx, ReqCtx, Deadline, State) ->
-    process(Impact, ProcessingCtx, ReqCtx, Deadline, undefined, State).
-
--spec process(
-    processor_impact(), processing_context(), request_context(), mg_utils:deadline(), process_retry_strategy(), state()
-) ->
-    state().
-process(Impact, ProcessingCtx, ReqCtx, Deadline, RetryStrat, State = #{id := ID, namespace := NS, options := Opts}) ->
+process(Impact, ProcessingCtx, ReqCtx, Deadline, State = #{id := ID, namespace := NS, options := Opts}) ->
     try
-        process_unsafe(Impact, ProcessingCtx, ReqCtx, Deadline, RetryStrat, try_init_state(Impact, State))
+        NewState = process_unsafe(Impact, ProcessingCtx, ReqCtx, Deadline, try_init_state(Impact, State)),
+        clean_retry_strategy(NewState)
     catch
         throw:(Reason=({ErrorType, _Details})):ST when ?can_be_retried(ErrorType) ->
             ok = emit_beat(Opts, #mg_machine_process_transient_error{
@@ -660,26 +651,50 @@ process(Impact, ProcessingCtx, ReqCtx, Deadline, RetryStrat, State = #{id := ID,
                 request_context = ReqCtx
             }),
             ok = do_reply_action({reply, {error, Reason}}, ProcessingCtx),
-            try_process_retry(Impact, ProcessingCtx, ReqCtx, Deadline, RetryStrat, State);
+            process_retry(Impact, ProcessingCtx, ReqCtx, Deadline, State);
         Class:Reason:ST ->
             ok = do_reply_action({reply, {error, {logic, machine_failed}}}, ProcessingCtx),
             handle_exception({Class, Reason, ST}, Impact, ReqCtx, Deadline, State)
     end.
 
--spec try_process_retry(
-    processor_impact(), processing_context(), request_context(), mg_utils:deadline(), process_retry_strategy(), state()
-) ->
+-spec process_retry(processor_impact(), processing_context(), request_context(), mg_utils:deadline(), state()) ->
     state().
-try_process_retry(_Impact, _ProcessingCtx, _ReqCtx, _Deadline, undefined, State) ->
+process_retry(Impact, ProcessingCtx, ReqCtx, Deadline, State) when
+    Impact =:= continuation
+->
+    try
+        do_process_retry(Impact, ProcessingCtx, ReqCtx, Deadline, init_retry_strategy(Impact, Deadline, State))
+    catch
+        Class:Reason:ST -> %% I miss get_stacktrace
+            ok = do_reply_action({reply, {error, {logic, machine_failed}}}, ProcessingCtx),
+            handle_exception({Class, Reason, ST}, Impact, ReqCtx, Deadline, State)
+    end;
+process_retry(_Impact, _ProcessingCtx, _ReqCtx, _Deadline, State) ->
+    State.
+
+-spec init_retry_strategy(processor_impact(), mg_utils:deadline(), state()) ->
+    state().
+init_retry_strategy(_, _, State = #{retry_strategy := _}) ->
     State;
-try_process_retry(Impact, ProcessingCtx, ReqCtx, Deadline, RetryStrategy, State) ->
+init_retry_strategy(Impact, Deadline, State = #{options := Options}) ->
+    RetryStrategy = retry_strategy({processor_impact, Impact}, Options, Deadline),
+    State#{retry_strategy => RetryStrategy}.
+
+-spec do_process_retry(processor_impact(), processing_context(), request_context(), mg_utils:deadline(), state()) ->
+    state().
+do_process_retry(Impact, ProcessingCtx, ReqCtx, Deadline, State = #{retry_strategy := RetryStrategy}) ->
     case genlib_retry:next_step(RetryStrategy) of
         {wait, Timeout, NewRetryStrategy} ->
             ok = timer:sleep(Timeout),
-            process(Impact, ProcessingCtx, ReqCtx, Deadline, NewRetryStrategy, State);
+            process(Impact, ProcessingCtx, ReqCtx, Deadline, State#{retry_strategy => NewRetryStrategy});
         finish ->
-            throw({permanent, process_retries_exhausted})
+            throw({permanent, retries_exhausted})
     end.
+
+-spec clean_retry_strategy(state()) ->
+        state().
+clean_retry_strategy(State) ->
+    maps:without([retry_strategy], State).
 
 -spec try_init_state(processor_impact(), state()) ->
     state().
@@ -712,11 +727,9 @@ handle_exception(Exception, Impact, ReqCtx, Deadline, State) ->
             transit_state(ReqCtx, Deadline, NewStorageMachine, State)
     end.
 
--spec process_unsafe(
-    processor_impact(), processing_context(), request_context(), mg_utils:deadline(), process_retry_strategy(), state()
-) ->
+-spec process_unsafe(processor_impact(), processing_context(), request_context(), mg_utils:deadline(), state()) ->
     state().
-process_unsafe(Impact, ProcessingCtx, ReqCtx, Deadline, RetryStrat, State = #{storage_machine := StorageMachine}) ->
+process_unsafe(Impact, ProcessingCtx, ReqCtx, Deadline, State = #{storage_machine := StorageMachine}) ->
     ok = emit_pre_process_beats(Impact, ReqCtx, Deadline, State),
     ProcessStart = erlang:monotonic_time(),
     {ReplyAction, Action, NewMachineState} =
@@ -745,7 +758,7 @@ process_unsafe(Impact, ProcessingCtx, ReqCtx, Deadline, RetryStrat, State = #{st
             % продолжение обработки машины делается без дедлайна
             % предполагается, что машина должна рано или поздно завершить свои дела или упасть
             NewProcessingCtx = ProcessingCtx#{state := NewProcessingSubState},
-            process(continuation, NewProcessingCtx, ReqCtx, undefined, RetryStrat, NewState);
+            process(continuation, NewProcessingCtx, ReqCtx, undefined, NewState);
         _ ->
             NewState
     end.

--- a/apps/mg/test/mg_continuation_retry_SUITE.erl
+++ b/apps/mg/test/mg_continuation_retry_SUITE.erl
@@ -1,0 +1,256 @@
+%%%
+%%% Copyright 2019 RBKmoney
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%
+
+-module(mg_continuation_retry_SUITE).
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+%% tests descriptions
+-export([all           /0]).
+-export([groups        /0]).
+-export([init_per_suite/1]).
+-export([end_per_suite /1]).
+
+%% tests
+-export([continuation_delayed_retries_test/1]).
+
+%% mg_machine
+-behaviour(mg_machine).
+-export([process_machine/7]).
+
+%% Pulse
+-export([handle_beat/2]).
+
+%%
+%% tests descriptions
+%%
+-type group_name() :: atom().
+-type test_name () :: atom().
+-type config    () :: [{atom(), _}].
+
+-spec all() ->
+    [test_name()].
+all() ->
+    [
+        {group, main}
+    ].
+
+-spec groups() ->
+    [{group_name(), list(_), test_name()}].
+groups() ->
+    [
+        {main, [sequence], [
+            continuation_delayed_retries_test
+        ]}
+    ].
+
+%%
+%% starting/stopping
+%%
+-spec init_per_suite(config()) ->
+    config().
+init_per_suite(C) ->
+    % dbg:tracer(), dbg:p(all, c),
+    % dbg:tpl({mg_events_sink_machine, '_', '_'}, x),
+    Apps = mg_ct_helper:start_applications([mg]),
+    Pid = start_event_sink(event_sink_options()),
+    true = erlang:unlink(Pid),
+    [{apps, Apps}, {pid, Pid} | C].
+
+-spec end_per_suite(config()) ->
+    ok.
+end_per_suite(C) ->
+    true = erlang:exit(?config(pid, C), kill),
+    mg_ct_helper:stop_applications(?config(apps, C)).
+
+
+%%
+%% tests
+%%
+-define(TEST_FAIL_COUNT, 3).
+-define(TEST_INTERVALS, [100, 200, 300]).
+-define(TEST_INTERVAL_THRESHOLD, 99).
+-define(REQ_CTX, <<"req_ctx">>).
+-define(ES_ID, <<"event_sink_id">>).
+-define(MH_ID, <<"42">>).
+-define(MH_NS, <<"42_ns">>).
+-define(ETS_NS, ?MODULE).
+
+-spec continuation_delayed_retries_test(config()) ->
+    _.
+continuation_delayed_retries_test(_C) ->
+    Options = automaton_options(),
+    _  = start_automaton(Options),
+    ID = ?MH_ID,
+    ok = mg_machine:start(Options, ID, #{},  ?REQ_CTX, mg_utils:default_deadline()),
+    ok = mg_machine:call (Options, ID, test, ?REQ_CTX, mg_utils:default_deadline()),
+    ok = await_process_done(Options, ID, 100),
+    ok = check_event_intervals().
+
+%%
+%% processor
+%%
+
+-spec process_machine(_Options, mg:id(), mg_machine:processor_impact(), _, _, _, mg_machine:machine_state()) ->
+    mg_machine:processor_result() | no_return().
+process_machine(_, _, {_, fail}, _, ?REQ_CTX, _, _) ->
+    _ = exit(1),
+    {noreply, sleep, []};
+process_machine(_, _, {init, InitState}, _, ?REQ_CTX, _, null) ->
+    _ = ets:new(?ETS_NS, [set, named_table, public]),
+    {{reply, ok}, sleep, InitState};
+process_machine(_, _, {call, test}, _, ?REQ_CTX, _, State) ->
+    true = ets:insert(?ETS_NS, {fail_count, 0}),
+    {{reply, ok}, {continue, #{}}, State};
+process_machine(_, _, continuation, _, ?REQ_CTX, _, State) ->
+    [{fail_count, FailCount}] = ets:lookup(?ETS_NS, fail_count),
+    case FailCount of
+        ?TEST_FAIL_COUNT ->
+            _ = add_event(<<"done">>, FailCount),
+            {noreply, sleep, State#{<<"done">> => true}};
+        _ ->
+            _ = add_event(<<"fail">>, FailCount),
+            true = ets:insert(?ETS_NS, {fail_count, FailCount + 1}),
+            throw({transient, not_yet})
+    end.
+
+%%
+%% utils
+%%
+-spec await_process_done(mg_machine:options(), binary(), timeout()) ->
+    ok.
+await_process_done(Options, ID, Timeout) ->
+    case get_last_event() of
+        {_, _, <<"done">>} -> ok;
+        _ ->
+            timer:sleep(Timeout),
+            await_process_done(Options, ID, Timeout)
+    end.
+
+-spec check_event_intervals() ->
+    ok.
+check_event_intervals() ->
+    History = get_history(),
+    _ = ct:pal("~p", [History]),
+    Invervals = count_intervals(History),
+    ?assertEqual(true, assert_intervals(?TEST_INTERVALS, Invervals, ?TEST_INTERVAL_THRESHOLD)),
+    ok.
+
+-spec assert_intervals(_Target, _Actual, _Threshhold) ->
+    boolean().
+assert_intervals([H1 | T1], [H2 | T2], Threshhold) when H1 + Threshhold >= H2 ->
+    assert_intervals(T1, T2, Threshhold);
+assert_intervals([], [], _) ->
+    true;
+assert_intervals(_, _, _) ->
+    false.
+
+-spec count_intervals(_History) ->
+    _.
+count_intervals([{_, CreatedAt, _} | Rest]) ->
+    count_intervals(CreatedAt, Rest, []).
+
+-spec count_intervals(_PrevAt, _History, _Acc) ->
+    _.
+count_intervals(PrevAt, [{_, CurrentAt, _} | Rest], Acc) ->
+    count_intervals(CurrentAt, Rest, Acc ++ [CurrentAt - PrevAt]);
+count_intervals(_, [], Acc) ->
+    Acc.
+
+-spec add_event(_EventBody, _ID) ->
+    _.
+add_event(EventBody, ID) ->
+    Event = #{
+        id         => ID,
+        created_at => os:system_time(millisecond),
+        body       => {#{}, EventBody}
+    },
+    mg_events_sink_machine:add_events(event_sink_options(), ?MH_NS, ?MH_ID,
+        [Event], null, mg_utils:default_deadline()).
+
+-spec get_last_event() ->
+    _.
+get_last_event() ->
+    case get_history({undefined, 1, backward}) of
+        [Event] -> Event;
+        [] -> undefined
+    end.
+
+-spec get_history() ->
+    _.
+get_history() ->
+    HRange = {undefined, undefined, forward},
+    get_history(HRange).
+
+-define(parse_event(ID, CreatedAt, Body),
+    #{id := ID, body := #{event := #{created_at := CreatedAt, body := {_, Body}}}}).
+
+-spec get_history(Range::tuple()) ->
+    _.
+get_history(HRange) ->
+    EventsSinkEvents = mg_events_sink_machine:get_history(event_sink_options(), ?MH_ID, HRange),
+    [{ID, CreatedAt, Body} || ?parse_event(ID, CreatedAt, Body) <- EventsSinkEvents].
+
+-spec start_event_sink(mg_events_sink_machine:ns_options()) ->
+    pid().
+start_event_sink(Options) ->
+    mg_utils:throw_if_error(
+        mg_utils_supervisor_wrapper:start_link(
+            #{strategy => one_for_all},
+            [mg_events_sink_machine:child_spec(Options, event_sink)]
+        )
+    ).
+
+-spec start_automaton(mg_machine:options()) ->
+    pid().
+start_automaton(Options) ->
+    mg_utils:throw_if_error(mg_machine:start_link(Options)).
+
+-spec automaton_options() ->
+    mg_machine:options().
+automaton_options() ->
+    #{
+        namespace => ?MH_NS,
+        processor => ?MODULE,
+        storage   => mg_storage_memory,
+        pulse     => ?MODULE,
+        retries   => #{
+            continuation => {intervals, ?TEST_INTERVALS}
+        },
+        schedulers => #{
+            timers         => #{ interval => 1000 },
+            timers_retries => #{ interval => 1000 },
+            overseer       => #{ interval => 1000 }
+        }
+    }.
+
+-spec event_sink_options() ->
+    mg_events_sink_machine:options().
+event_sink_options() ->
+    #{
+        name                   => machine,
+        machine_id             => ?MH_ID,
+        namespace              => ?MH_NS,
+        storage                => mg_storage_memory,
+        pulse                  => ?MODULE,
+        duplicate_search_batch => 1000,
+        events_storage         => mg_storage_memory
+    }.
+
+-spec handle_beat(_, mg_pulse:beat()) ->
+    ok.
+handle_beat(_, Beat) ->
+    ct:pal("~p", [Beat]).

--- a/apps/mg/test/mg_continuation_retry_SUITE.erl
+++ b/apps/mg/test/mg_continuation_retry_SUITE.erl
@@ -20,7 +20,6 @@
 
 %% tests descriptions
 -export([all           /0]).
--export([groups        /0]).
 -export([init_per_suite/1]).
 -export([end_per_suite /1]).
 
@@ -37,7 +36,6 @@
 %%
 %% tests descriptions
 %%
--type group_name() :: atom().
 -type test_name () :: atom().
 -type config    () :: [{atom(), _}].
 
@@ -45,16 +43,7 @@
     [test_name()].
 all() ->
     [
-        {group, main}
-    ].
-
--spec groups() ->
-    [{group_name(), list(_), test_name()}].
-groups() ->
-    [
-        {main, [sequence], [
-            continuation_delayed_retries_test
-        ]}
+        continuation_delayed_retries_test
     ].
 
 %%
@@ -229,11 +218,6 @@ automaton_options() ->
         pulse     => ?MODULE,
         retries   => #{
             continuation => {intervals, ?TEST_INTERVALS}
-        },
-        schedulers => #{
-            timers         => #{ interval => 1000 },
-            timers_retries => #{ interval => 1000 },
-            overseer       => #{ interval => 1000 }
         }
     }.
 

--- a/apps/mg/test/mg_continuation_retry_SUITE.erl
+++ b/apps/mg/test/mg_continuation_retry_SUITE.erl
@@ -73,7 +73,6 @@ end_per_suite(C) ->
 -define(TEST_INTERVALS, [100, 200, 300]).
 -define(TEST_INTERVAL_THRESHOLD, 99).
 -define(REQ_CTX, <<"req_ctx">>).
--define(ES_ID, <<"event_sink_id">>).
 -define(MH_ID, <<"42">>).
 -define(MH_NS, <<"42_ns">>).
 -define(ETS_NS, ?MODULE).

--- a/apps/mg/test/mg_continuation_retry_SUITE.erl
+++ b/apps/mg/test/mg_continuation_retry_SUITE.erl
@@ -55,23 +55,18 @@ init_per_suite(C) ->
     % dbg:tracer(), dbg:p(all, c),
     % dbg:tpl({mg_events_sink_machine, '_', '_'}, x),
     Apps = mg_ct_helper:start_applications([mg]),
-    Pid = start_event_sink(event_sink_options()),
-    true = erlang:unlink(Pid),
-    [{apps, Apps}, {pid, Pid} | C].
+    [{apps, Apps} | C].
 
 -spec end_per_suite(config()) ->
     ok.
 end_per_suite(C) ->
-    true = erlang:exit(?config(pid, C), kill),
     mg_ct_helper:stop_applications(?config(apps, C)).
-
 
 %%
 %% tests
 %%
--define(TEST_FAIL_COUNT, 3).
--define(TEST_INTERVALS, [100, 200, 300]).
--define(TEST_INTERVAL_THRESHOLD, 99).
+-define(TEST_SLEEP, 500).
+-define(TEST_INTERVALS, [100, 10000]).
 -define(REQ_CTX, <<"req_ctx">>).
 -define(MH_ID, <<"42">>).
 -define(MH_NS, <<"42_ns">>).
@@ -85,8 +80,8 @@ continuation_delayed_retries_test(_C) ->
     ID = ?MH_ID,
     ok = mg_machine:start(Options, ID, #{},  ?REQ_CTX, mg_utils:default_deadline()),
     ok = mg_machine:call (Options, ID, test, ?REQ_CTX, mg_utils:default_deadline()),
-    ok = await_process_done(Options, ID, 100),
-    ok = check_event_intervals().
+    ok = timer:sleep(?TEST_SLEEP),
+    2  = get_fail_count().
 
 %%
 %% processor
@@ -94,113 +89,32 @@ continuation_delayed_retries_test(_C) ->
 
 -spec process_machine(_Options, mg:id(), mg_machine:processor_impact(), _, _, _, mg_machine:machine_state()) ->
     mg_machine:processor_result() | no_return().
-process_machine(_, _, {_, fail}, _, ?REQ_CTX, _, _) ->
-    _ = exit(1),
-    {noreply, sleep, []};
 process_machine(_, _, {init, InitState}, _, ?REQ_CTX, _, null) ->
     _ = ets:new(?ETS_NS, [set, named_table, public]),
     {{reply, ok}, sleep, InitState};
 process_machine(_, _, {call, test}, _, ?REQ_CTX, _, State) ->
     true = ets:insert(?ETS_NS, {fail_count, 0}),
     {{reply, ok}, {continue, #{}}, State};
-process_machine(_, _, continuation, _, ?REQ_CTX, _, State) ->
-    [{fail_count, FailCount}] = ets:lookup(?ETS_NS, fail_count),
-    case FailCount of
-        ?TEST_FAIL_COUNT ->
-            _ = add_event(<<"done">>, FailCount),
-            {noreply, sleep, State#{<<"done">> => true}};
-        _ ->
-            _ = add_event(<<"fail">>, FailCount),
-            true = ets:insert(?ETS_NS, {fail_count, FailCount + 1}),
-            throw({transient, not_yet})
-    end.
+process_machine(_, _, continuation, _, ?REQ_CTX, _, _State) ->
+    FailCount = get_fail_count(),
+    ok = update_fail_count(FailCount + 1),
+    throw({transient, not_yet}).
 
 %%
 %% utils
 %%
--spec await_process_done(mg_machine:options(), binary(), timeout()) ->
+
+-spec get_fail_count() ->
+    non_neg_integer().
+get_fail_count() ->
+    [{fail_count, FailCount}] = ets:lookup(?ETS_NS, fail_count),
+    FailCount.
+
+-spec update_fail_count(non_neg_integer()) ->
     ok.
-await_process_done(Options, ID, Timeout) ->
-    case get_last_event() of
-        {_, _, <<"done">>} -> ok;
-        _ ->
-            timer:sleep(Timeout),
-            await_process_done(Options, ID, Timeout)
-    end.
-
--spec check_event_intervals() ->
+update_fail_count(FailCount) ->
+    true = ets:insert(?ETS_NS, {fail_count, FailCount}),
     ok.
-check_event_intervals() ->
-    History = get_history(),
-    _ = ct:pal("~p", [History]),
-    Invervals = count_intervals(History),
-    ?assertEqual(true, assert_intervals(?TEST_INTERVALS, Invervals, ?TEST_INTERVAL_THRESHOLD)),
-    ok.
-
--spec assert_intervals(_Target, _Actual, _Threshhold) ->
-    boolean().
-assert_intervals([H1 | T1], [H2 | T2], Threshhold) when H1 + Threshhold >= H2 ->
-    assert_intervals(T1, T2, Threshhold);
-assert_intervals([], [], _) ->
-    true;
-assert_intervals(_, _, _) ->
-    false.
-
--spec count_intervals(_History) ->
-    _.
-count_intervals([{_, CreatedAt, _} | Rest]) ->
-    count_intervals(CreatedAt, Rest, []).
-
--spec count_intervals(_PrevAt, _History, _Acc) ->
-    _.
-count_intervals(PrevAt, [{_, CurrentAt, _} | Rest], Acc) ->
-    count_intervals(CurrentAt, Rest, Acc ++ [CurrentAt - PrevAt]);
-count_intervals(_, [], Acc) ->
-    Acc.
-
--spec add_event(_EventBody, _ID) ->
-    _.
-add_event(EventBody, ID) ->
-    Event = #{
-        id         => ID,
-        created_at => os:system_time(millisecond),
-        body       => {#{}, EventBody}
-    },
-    mg_events_sink_machine:add_events(event_sink_options(), ?MH_NS, ?MH_ID,
-        [Event], null, mg_utils:default_deadline()).
-
--spec get_last_event() ->
-    _.
-get_last_event() ->
-    case get_history({undefined, 1, backward}) of
-        [Event] -> Event;
-        [] -> undefined
-    end.
-
--spec get_history() ->
-    _.
-get_history() ->
-    HRange = {undefined, undefined, forward},
-    get_history(HRange).
-
--define(parse_event(ID, CreatedAt, Body),
-    #{id := ID, body := #{event := #{created_at := CreatedAt, body := {_, Body}}}}).
-
--spec get_history(Range::tuple()) ->
-    _.
-get_history(HRange) ->
-    EventsSinkEvents = mg_events_sink_machine:get_history(event_sink_options(), ?MH_ID, HRange),
-    [{ID, CreatedAt, Body} || ?parse_event(ID, CreatedAt, Body) <- EventsSinkEvents].
-
--spec start_event_sink(mg_events_sink_machine:ns_options()) ->
-    pid().
-start_event_sink(Options) ->
-    mg_utils:throw_if_error(
-        mg_utils_supervisor_wrapper:start_link(
-            #{strategy => one_for_all},
-            [mg_events_sink_machine:child_spec(Options, event_sink)]
-        )
-    ).
 
 -spec start_automaton(mg_machine:options()) ->
     pid().
@@ -218,19 +132,6 @@ automaton_options() ->
         retries   => #{
             continuation => {intervals, ?TEST_INTERVALS}
         }
-    }.
-
--spec event_sink_options() ->
-    mg_events_sink_machine:options().
-event_sink_options() ->
-    #{
-        name                   => machine,
-        machine_id             => ?MH_ID,
-        namespace              => ?MH_NS,
-        storage                => mg_storage_memory,
-        pulse                  => ?MODULE,
-        duplicate_search_batch => 1000,
-        events_storage         => mg_storage_memory
     }.
 
 -spec handle_beat(_, mg_pulse:beat()) ->

--- a/rebar.lock
+++ b/rebar.lock
@@ -77,7 +77,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.4.1">>},3},
  {<<"woody">>,
   {git,"git@github.com:rbkmoney/woody_erlang.git",
-       {ref,"c396f927b5149d1b5589262773a9e6a39cb68d33"}},
+       {ref,"cf9dc0dad5074d120667626e750cf6ff045b5958"}},
   0},
  {<<"yamerl">>,
   {git,"git@github.com:rbkmoney/yamerl.git",

--- a/rel_scripts/configurator.escript
+++ b/rel_scripts/configurator.escript
@@ -271,6 +271,9 @@ namespace({NameStr, NSYamlConfig}, YamlConfig) ->
             transport_opts => #{
                 pool => erlang:list_to_atom(NameStr),
                 max_connections => ?C:conf([processor, pool_size], NSYamlConfig, 50)
+            },
+            resolver_opts => #{
+                ip_picker => random
             }
         },
         default_processing_timeout => Timeout(default_processing_timeout, "30S"),

--- a/rel_scripts/configurator.escript
+++ b/rel_scripts/configurator.escript
@@ -282,11 +282,12 @@ namespace({NameStr, NSYamlConfig}, YamlConfig) ->
         timer_processing_timeout => Timeout(timer_processing_timeout, "60S"),
         reschedule_timeout => Timeout(reschedule_timeout, "60S"),
         retries => #{
-            storage   => {exponential, infinity, 2, 10, 60 * 1000},
+            storage      => {exponential, infinity, 2, 10, 60 * 1000},
             %% max_total_timeout not supported for timers yet, see mg_retry:new_strategy/2 comments
             %% actual timers sheduling resolution is one second
-            timers    => {exponential, 100, 2, 1000, 30 * 60 * 1000},
-            processor => {exponential, {max_total_timeout, 24 * 60 * 60 * 1000}, 2, 10, 60 * 1000}
+            timers       => {exponential, 100, 2, 1000, 30 * 60 * 1000},
+            processor    => {exponential, {max_total_timeout, 24 * 60 * 60 * 1000}, 2, 10, 60 * 1000},
+            continuation => {exponential, infinity, 2, 10, 60 * 1000}
         },
         schedulers => #{
             timers         => #{


### PR DESCRIPTION
Добавил опциональную поддержку `mg_retry` при транзиентных ошибках в `process(...)`. Если задать стратегию, то вместо хождений между `process -> handle_call` он будет ретраить себя сам. Пока не уверен как бы это протестировать.