### PR TITLE
MG-153: Schedule worker unload even upon init

### DIFF
--- a/apps/mg/src/mg_worker.erl
+++ b/apps/mg/src/mg_worker.erl
@@ -166,7 +166,7 @@ init({ID, Options = #{worker := WorkerModOpts}, ReqCtx}) ->
             hibernate_timeout => HibernateTimeout,
             unload_timeout    => UnloadTimeout
         },
-    {ok, State}.
+    {ok, schedule_unload_timer(State)}.
 
 -spec handle_call(_Call, mg_utils:gen_server_from(), state()) ->
     mg_utils:gen_server_handle_call_ret(state()).
@@ -211,7 +211,7 @@ handle_info({timeout, TRef, unload}, State=#{mod:=Mod, unload_tref:=TRef, status
     case Status of
         {working, ModState} ->
             _ = Mod:handle_unload(ModState);
-        {loading, _} ->
+        {loading, _, _} ->
             ok
     end,
     {stop, normal, State};


### PR DESCRIPTION
С введением регистрации через consuela мы можем получить подвисшие воркеры. Это проявляется при повышенной нагрузке на workers manager, который встаёт в очередь к consuela registry на каждую очередную регистрацию. Воркер в итоге может запуститься, но не успевает обработать call из-за истечения deadline, и остаётся в состоянии `loading`.

По-хорошему кажется это нужно решать переносом регистрации в воркеров и введением контроля перегрузки consuela registry, но пока так.