### PR TITLE
MG-153: Drop queue length control in workers

### DIFF
--- a/apps/mg/include/pulse.hrl
+++ b/apps/mg/include/pulse.hrl
@@ -187,9 +187,7 @@
     namespace :: mg:ns(),
     machine_id :: mg:id(),
     request_context :: mg:request_context(),
-    deadline :: mg_utils:deadline(),
-    msg_queue_len :: non_neg_integer(),
-    msg_queue_limit :: mg_workers_manager:queue_limit()
+    deadline :: mg_utils:deadline()
 }).
 
 -record(mg_worker_start_attempt, {

--- a/apps/mg/src/mg_workers_manager.erl
+++ b/apps/mg/src/mg_workers_manager.erl
@@ -89,10 +89,7 @@ call(Options, ID, Call, ReqCtx, Deadline) ->
     case mg_utils:is_deadline_reached(Deadline) of
         false ->
             #{name := Name, pulse := Pulse} = Options,
-            MsgQueueLimit = message_queue_len_limit(Options),
-            try
-                mg_worker:call(Name, ID, Call, ReqCtx, Deadline, MsgQueueLimit, Pulse)
-            catch
+            try mg_worker:call(Name, ID, Call, ReqCtx, Deadline, Pulse) catch
                 exit:Reason ->
                     handle_worker_exit(Options, ID, Call, ReqCtx, Deadline, Reason)
             end;

--- a/apps/mg_woody_api/src/mg_woody_api_pulse_metric.erl
+++ b/apps/mg_woody_api/src/mg_woody_api_pulse_metric.erl
@@ -142,12 +142,9 @@ create_metric(#mg_scheduler_quota_reserved{} = Beat) ->
         create_gauge([mg, scheduler, NS, Name, quota, reserved], Reserved)
     ];
 % Workers management
-create_metric(#mg_worker_call_attempt{namespace = NS, msg_queue_len = QLen, msg_queue_limit = QLimit}) ->
-    QUsage = calc_queue_usage(QLen, QLimit),
+create_metric(#mg_worker_call_attempt{namespace = NS}) ->
     [
-        create_inc([mg, workers, NS, call_attempt]),
-        create_bin_inc([mg, workers, NS, call_attempt, queue_usage], fraction, QUsage),
-        create_bin_inc([mg, workers, NS, call_attempt, queue_len], queue_length, QLen)
+        create_inc([mg, workers, NS, call_attempt])
     ];
 create_metric(#mg_worker_start_attempt{namespace = NS, msg_queue_len = QLen, msg_queue_limit = QLimit}) ->
     QUsage = calc_queue_usage(QLen, QLimit),

--- a/apps/mg_woody_api/test/mg_metric_SUITE.erl
+++ b/apps/mg_woody_api/test/mg_metric_SUITE.erl
@@ -146,11 +146,9 @@ fraction_and_queue_bin_metric_test(_C) ->
     Samples = lists:seq(0, 200, 1),
     _ = [
         ok = test_beat(#mg_worker_call_attempt{
-            namespace = ?NS,
-            msg_queue_len = Sample,
-            msg_queue_limit = 100
+            namespace = ?NS
         })
-        || Sample <- Samples
+        || _ <- Samples
     ].
 
 -spec duration_bin_metric_test(config()) -> _.

--- a/apps/mg_woody_api/test/mg_metric_SUITE.erl
+++ b/apps/mg_woody_api/test/mg_metric_SUITE.erl
@@ -145,10 +145,12 @@ offset_bin_metric_test(_C) ->
 fraction_and_queue_bin_metric_test(_C) ->
     Samples = lists:seq(0, 200, 1),
     _ = [
-        ok = test_beat(#mg_worker_call_attempt{
-            namespace = ?NS
+        ok = test_beat(#mg_worker_start_attempt{
+            namespace = ?NS,
+            msg_queue_len = Sample,
+            msg_queue_limit = 100
         })
-        || _ <- Samples
+        || Sample <- Samples
     ].
 
 -spec duration_bin_metric_test(config()) -> _.


### PR DESCRIPTION
На текущий момент кажется довольно адекватным решением. От machine based event sink мы всё равно отказываемся, а профиль нагрузки на остальные типы машин кажется пока не предполагает необходимость подобного контроля. Мы рискуем перееданием памяти, но мы можем сделать так, что от этого будет умирать не нода, а только один процесс.

Идеальным решением было бы завести managed mailbox process для воркера или (даже лучше) переделать воркера в async task host.