### PR TITLE
Provide indeterminate error reason when worker killed

### DIFF
--- a/apps/mg/src/mg_workers_manager.erl
+++ b/apps/mg/src/mg_workers_manager.erl
@@ -145,7 +145,7 @@ handle_worker_exit(Options, ID, Call, ReqCtx, Deadline, Reason, CanRetry) ->
         {normal    , _MFA}     -> MaybeRetry(normal);
         {shutdown  , _MFA}     -> MaybeRetry(shutdown);
         {timeout   , _MFA}     -> {error, Reason};
-        {killed    , _MFA}     -> {error, {transient, unavailable}};
+        {killed    , _MFA}     -> {error, {timeout, killed}};
         {transient , _Details} -> {error, Reason};
         Unknown                -> {error, {unexpected_exit, Unknown}}
     end.


### PR DESCRIPTION
...While handling a call for example. Since it's a regular situation for distributed setup, because of peer nodes going up and down constantly, we better be more conservative with error mapping.