### PR TITLE
Demote consuela's zombie reaper events to debug logging level

### DIFF
--- a/apps/mg_woody_api/src/mg_woody_api_pulse_log.erl
+++ b/apps/mg_woody_api/src/mg_woody_api_pulse_log.erl
@@ -218,11 +218,11 @@ format_consuela_beat({session_keeper, {session, destroyed}}) ->
 format_consuela_beat({zombie_reaper, {{zombie, {Rid, Name, Pid}}, Status}}) ->
     {Level, Format, Context} = case Status of
         enqueued ->
-            {info, {"enqueued zombie registration ~p as ~p", [Pid, Name]}, [
+            {debug, {"enqueued zombie registration ~p as ~p", [Pid, Name]}, [
                 {mg_pulse_event_id, consuela_zombie_enqueued}
             ]};
         {reaping, succeeded} ->
-            {info, {"reaped zombie registration ~p as ~p", [Pid, Name]}, [
+            {debug, {"reaped zombie registration ~p as ~p", [Pid, Name]}, [
                 {mg_pulse_event_id, consuela_zombie_reaped}
             ]};
         {reaping, {failed, Reason}} ->


### PR DESCRIPTION
Zombie reaper nowadays reaps every died process registration, what amounts to whole 2 informational log messages, which is obviously not what we would want.