### PR TITLE
 Allow to configure more scheduler and riak backend opts

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -109,9 +109,10 @@ namespaces:
             pool_size: 50
             http_keep_alive_timeout: 10s
         timers:
-            scan_interval: 30s
+            scan_interval: 1m
             scan_limit: 1000
             capacity: 500
+            min_scan_delay: 10s
         overseer: disabled
         # maximum number of events that will be stored inside of machine state
         # must be non negative integer, default is 0

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -130,6 +130,7 @@ storage:
 #        queue_max: 1000
 #     connect_timeout: 5S
 #     request_timeout: 10S
+#     index_query_timeout: 10S
 #     batch_concurrency_limit: 50
 
 ## kafka settings example

--- a/rebar.lock
+++ b/rebar.lock
@@ -45,7 +45,7 @@
   0},
  {<<"machinegun_core">>,
   {git,"https://github.com/rbkmoney/machinegun_core",
-       {ref,"69cd1e77edf18399a37c220b683c8a0684e2ab77"}},
+       {ref,"6b23b79edb45fc9a72a7ddc8afb3a30144c3d6d4"}},
   0},
  {<<"machinegun_woody_api">>,
   {git,"https://github.com/rbkmoney/machinegun_woody_api",

--- a/rel_scripts/configurator.escript
+++ b/rel_scripts/configurator.escript
@@ -471,15 +471,15 @@ scheduler(Share, Config) ->
 timer_scheduler(Share, Config) ->
     (scheduler(Share, Config))#{
         capacity       => ?C:conf([capacity], Config, 1000),
-        min_scan_delay => 1000,
+        min_scan_delay => timeout(min_scan_delay, Config, "1s", ms),
         target_cutoff  => timeout(scan_interval, Config, "60s", sec)
     }.
 
 overseer_scheduler(Share, Config) ->
     (scheduler(Share, Config))#{
         capacity       => ?C:conf([capacity], Config, 1000),
-        min_scan_delay => 1000,
-        rescan_delay   => 10 * 60 * 1000
+        min_scan_delay => timeout(min_scan_delay, Config, "1s", ms),
+        rescan_delay   => timeout(scan_interval, Config, "10m", ms)
     }.
 
 timeout(Name, Config, Default, Unit) ->

--- a/rel_scripts/configurator.escript
+++ b/rel_scripts/configurator.escript
@@ -374,6 +374,7 @@ storage(NS, YamlConfig) ->
                 bucket => NS,
                 connect_timeout => ?C:time_interval(?C:conf([storage, connect_timeout  ], YamlConfig, "5S" ), ms),
                 request_timeout => ?C:time_interval(?C:conf([storage, request_timeout  ], YamlConfig, "10S"), ms),
+                index_query_timeout => ?C:time_interval(?C:conf([storage, index_query_timeout], YamlConfig, "10S"), ms),
                 pool_options => #{
                     % If `init_count` is greater than zero, then the service will not start
                     % if the riak is unavailable. The `pooler` synchronously creates `init_count`


### PR DESCRIPTION
* index query timeout @ riak backend
* min_scan_delay @ any scheduler
* rescan_delay @ overseers
