### PR TITLE
MSPF-579 Fix prometheus metrics handling

### DIFF
--- a/src/machinegun_pulse_prometheus.erl
+++ b/src/machinegun_pulse_prometheus.erl
@@ -297,22 +297,26 @@ dispatch_metrics(_Beat) ->
 -spec inc(metric_name(), [metric_label_value()]) ->
     ok.
 inc(Name, Labels) ->
-    prometheus_counter:inc(registry(), Name, Labels, 1).
+    _ = prometheus_counter:inc(registry(), Name, Labels, 1),
+    ok.
 
 -spec inc(metric_name(), [metric_label_value()], number()) ->
     ok.
 inc(Name, Labels, Value) ->
-    prometheus_counter:inc(registry(), Name, Labels, Value).
+    _ = prometheus_counter:inc(registry(), Name, Labels, Value),
+    ok.
 
 -spec set(metric_name(), [metric_label_value()], number()) ->
     ok.
 set(Name, Labels, Value) ->
-    prometheus_gauge:set(registry(), Name, Labels, Value).
+    _ = prometheus_gauge:set(registry(), Name, Labels, Value),
+    ok.
 
 -spec observe(metric_name(), [metric_label_value()], number()) ->
     ok.
 observe(Name, Labels, Value) ->
-    prometheus_histogram:observe(registry(), Name, Labels, Value).
+    _ = prometheus_histogram:observe(registry(), Name, Labels, Value),
+    ok.
 
 -spec registry() ->
     prometheus_registry:registry().

--- a/src/machinegun_riak_metric.erl
+++ b/src/machinegun_riak_metric.erl
@@ -356,17 +356,20 @@ try_decode_pool_name(PoolName) ->
 -spec inc(prometheus_metric:name(), [term()], number()) ->
     ok.
 inc(Name, Labels, Value) ->
-    prometheus_counter:inc(registry(), Name, Labels, Value).
+    _ = prometheus_counter:inc(registry(), Name, Labels, Value),
+    ok.
 
 -spec set(prometheus_metric:name(), [term()], number()) ->
     ok.
 set(Name, Labels, Value) ->
-    prometheus_gauge:set(registry(), Name, Labels, Value).
+    _ = prometheus_gauge:set(registry(), Name, Labels, Value),
+    ok.
 
 -spec observe(prometheus_metric:name(), [term()], number()) ->
     ok.
 observe(Name, Labels, Value) ->
-    prometheus_histogram:observe(registry(), Name, Labels, Value).
+    _ = prometheus_histogram:observe(registry(), Name, Labels, Value),
+    ok.
 
 -spec registry() ->
     prometheus_registry:registry().


### PR DESCRIPTION
`prometheus_histogram:observe/4` can return not only `ok` :(
It signals about errors by exceptions, so let's just ignore the result